### PR TITLE
Add admin brands and child routes

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -4,6 +4,7 @@ import { LoginAdmin, LoginCompany } from './scenes/Login/scenes';
 import { Brands, OBG, Users } from './scenes/Admin/scenes';
 import { Listings, People, Settings } from './scenes/Company/scenes';
 import { CompaniesAds, CompaniesAll } from './scenes/Admin/scenes/Companies/scenes';
+import { BrandForms, BrandObg, BrandSettings } from './scenes/Admin/scenes/Brands/scenes';
 
 const routes = {
   path: '/',
@@ -25,6 +26,29 @@ const routes = {
         {
           path: 'brands',
           component: Brands,
+          childRoutes: [
+            {
+              path: 'brand/:id',
+              indexRoute: { onEnter: (nextState, replace) => {
+                const { id } = nextState.params;
+                replace(`/admin/brands/brand/${id}/forms`);
+              } },
+              childRoutes: [
+                {
+                  path: 'forms',
+                  component: BrandForms,
+                },
+                {
+                  path: 'settings',
+                  component: BrandSettings,
+                },
+                {
+                  path: 'obg',
+                  component: BrandObg,
+                },
+              ],
+            },
+          ],
         },
         {
           path: 'companies',

--- a/src/scenes/Admin/scenes/Brands/components/AddBrandModal/index.js
+++ b/src/scenes/Admin/scenes/Brands/components/AddBrandModal/index.js
@@ -1,0 +1,146 @@
+import React, { PropTypes, Component } from 'react';
+import { Button, Card, Container, Row, Col, withModal } from 'paintcan';
+import { connect } from 'react-redux';
+import { CREATE_REQUEST } from '../../../../../../actionTypes';
+
+const AddBrandModal = withModal(
+  ({ isOpen, openModal }) => (
+    <Button active={isOpen} onClick={openModal} color="primary">
+      Add a new brand
+    </Button>
+  ),
+  ({ closeModal, createBrand, isCreateLoading }) => (
+    <AddBrandDialog
+      closeModal={closeModal}
+      createBrand={createBrand}
+      isCreateLoading={isCreateLoading}
+    />
+  ),
+);
+
+class AddBrandDialog extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      name: '',
+      image: '',
+      background: '',
+      text: '',
+      secondary: '',
+    };
+
+    this.submitHandler = this.submitHandler.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  submitHandler(e) {
+    e.preventDefault();
+    const { isCreateLoading, createBrand, closeModal } = this.props;
+
+    if (isCreateLoading) return;
+
+    const { name, image, background, text, secondary } = this.state;
+    createBrand(name, image, background, text, secondary);
+    closeModal();
+  }
+
+  handleChange(e) {
+    const { name, value } = e.target;
+    this.setState({ [name]: value });
+  }
+
+  render() {
+    const { submitHandler, handleChange } = this;
+    const { closeModal } = this.props;
+
+    return (
+      <Container fluid>
+        <Row align={{ xs: 'center' }}>
+          <Col size={{ xs: 10, lg: 4 }} align={{ xs: 'start' }}>
+            <Card>
+              <h3>Add new brand</h3>
+              <form onSubmit={submitHandler}>
+                <label htmlFor="name">Name</label><br />
+                <input
+                  type="text"
+                  id="name"
+                  name="name"
+                  onChange={handleChange}
+                  value={this.state.name}
+                /><br />
+                <label htmlFor="image">Image URL</label><br />
+                <input
+                  type="text"
+                  id="image"
+                  name="image"
+                  onChange={handleChange}
+                  value={this.state.image}
+                /><br />
+                <label htmlFor="background">Background Color: Hex</label><br />
+                <input
+                  type="text"
+                  id="background"
+                  name="background"
+                  onChange={handleChange}
+                  value={this.state.background}
+                /><br />
+                <label htmlFor="text">Text Color: Hex</label><br />
+                <input
+                  type="text"
+                  id="text"
+                  name="text"
+                  onChange={handleChange}
+                  value={this.state.text}
+                /><br />
+                <label htmlFor="secondary">Secondary Color: Hex</label><br />
+                <input
+                  type="text"
+                  id="secondary"
+                  name="secondary"
+                  onChange={handleChange}
+                  value={this.state.secondary}
+                /><br />
+                <input type="submit" value="Save Change" />
+              </form>
+              <Button onClick={closeModal}>
+                Cancel
+              </Button>
+            </Card>
+          </Col>
+        </Row>
+      </Container>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  isCreateLoading: state.store.isLoading.CREATE,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  createBrand: (name, image, background, text, secondary) => dispatch({
+    type: CREATE_REQUEST,
+    payload: {
+      type: 'brand',
+      record: {
+        name,
+        image,
+        background,
+        text,
+        secondary,
+      },
+    },
+  }),
+});
+
+AddBrandDialog.propTypes = {
+  closeModal: PropTypes.func,
+  createBrand: PropTypes.func,
+  isCreateLoading: PropTypes.bool,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(AddBrandModal);

--- a/src/scenes/Admin/scenes/Brands/components/List/components/ListItem/index.js
+++ b/src/scenes/Admin/scenes/Brands/components/List/components/ListItem/index.js
@@ -1,0 +1,24 @@
+/* eslint-disable react/jsx-no-bind */
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+import { Container, Row, Col, Button } from 'paintcan';
+
+const ListItem = ({ item, handleDelete }) => (
+  <Container fluid>
+    <Row>
+      <Col size={{ lg: 6 }}>
+        <Link to={`/admin/brands/brand/${item.id}`}>{item.name}</Link>
+      </Col>
+      <Col size={{ lg: 6 }}>
+        <Button onClick={handleDelete.bind(this, item.id)}>Delete</Button>
+      </Col>
+    </Row>
+  </Container>
+);
+
+ListItem.propTypes = {
+  item: PropTypes.object,
+  handleDelete: PropTypes.func,
+};
+
+export default ListItem;

--- a/src/scenes/Admin/scenes/Brands/components/List/index.js
+++ b/src/scenes/Admin/scenes/Brands/components/List/index.js
@@ -1,0 +1,22 @@
+import React, { PropTypes } from 'react';
+import ListItem from './components/ListItem';
+
+const List = ({ items, handleDelete }) => {
+  const keys = Object.keys(items);
+
+  return (<div>
+    {keys.map(key => (<ListItem
+      key={key}
+      item={items[key]}
+      handleDelete={handleDelete}
+    />)
+    )}
+  </div>);
+};
+
+List.propTypes = {
+  items: PropTypes.object,
+  handleDelete: PropTypes.func,
+};
+
+export default List;

--- a/src/scenes/Admin/scenes/Brands/index.js
+++ b/src/scenes/Admin/scenes/Brands/index.js
@@ -1,7 +1,83 @@
-import React from 'react';
+import React, { PropTypes, Component } from 'react';
+import { connect } from 'react-redux';
+import { Container, Row, Col } from 'paintcan';
+import List from './components/List';
+import AddBrandModal from './components/AddBrandModal';
+import { FIND_REQUEST, DELETE_REQUEST } from '../../../../actionTypes';
 
-const Brands = () => (
-  <p>Brands here</p>
-);
+class Brands extends Component {
+  constructor(props) {
+    super(props);
 
-export default Brands;
+    this.find = this.find.bind(this);
+    this.handleDelete = this.handleDelete.bind(this);
+  }
+
+  componentDidMount() {
+    this.find();
+  }
+
+  find() {
+    const { findBrands } = this.props;
+    findBrands();
+  }
+
+  handleDelete(id) {
+      // const { isDeleteLoading, deleteBrand } = this.props;
+    const { isDeleteLoading } = this.props;
+
+    if (isDeleteLoading) return;
+
+    console.log(`Delete brand ${id}`);
+    // FIXME: need to fix saga...
+    // deleteBrand(id); // dispatch action
+  }
+
+  render() {
+    const { brands } = this.props;
+
+    return (
+      <Container fluid><br />
+        <Row>
+          <Col size={{ xs: 4 }} align={{ xs: 'left' }}>
+            <AddBrandModal /><br /><br /><br />
+            {brands ? <List items={brands} handleDelete={this.handleDelete} /> : 'Loading...'}
+          </Col>
+        </Row>
+      </Container>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  brands: state.store.entities.brands,
+  isDeleteLoading: state.store.isLoading.DELETE,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  findBrands: () => dispatch({
+    type: FIND_REQUEST,
+    payload: {
+      type: 'brand',
+    },
+  }),
+  deleteBrand: (id) => dispatch({
+    type: DELETE_REQUEST,
+    payload: {
+      type: 'brand',
+      id,
+    },
+  }),
+});
+
+Brands.propTypes = {
+  brands: PropTypes.object,
+  findBrands: PropTypes.func,
+  isDeleteLoading: PropTypes.bool,
+  deleteBrand: PropTypes.func,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Brands);

--- a/src/scenes/Admin/scenes/Brands/scenes/BrandForms/index.js
+++ b/src/scenes/Admin/scenes/Brands/scenes/BrandForms/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const BrandForms = () => (
+  <p>Brand Forms</p>
+);
+
+export default BrandForms;

--- a/src/scenes/Admin/scenes/Brands/scenes/BrandObg/index.js
+++ b/src/scenes/Admin/scenes/Brands/scenes/BrandObg/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const BrandObg = () => (
+  <p>Brand OBG</p>
+);
+
+export default BrandObg;

--- a/src/scenes/Admin/scenes/Brands/scenes/BrandSettings/index.js
+++ b/src/scenes/Admin/scenes/Brands/scenes/BrandSettings/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const BrandSettings = () => (
+  <p>Brand Settings</p>
+);
+
+export default BrandSettings;

--- a/src/scenes/Admin/scenes/Brands/scenes/index.js
+++ b/src/scenes/Admin/scenes/Brands/scenes/index.js
@@ -1,0 +1,5 @@
+import BrandForms from './BrandForms';
+import BrandObg from './BrandObg';
+import BrandSettings from './BrandSettings';
+
+export { BrandForms, BrandObg, BrandSettings };


### PR DESCRIPTION
Currently the file structure is:
`Admin` (scenes) -> `Brands` (index, scenes) -> `BrandForms` etc.

In order to load the child routes of `Brands` the index needs to have `{children}` in the JSX, but I don't want to insert those components under `Brands`
